### PR TITLE
Relative tsconfig path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,8 @@
-import { join } from 'path'
 export = {
     parser: '@typescript-eslint/parser',
     parserOptions: {
         ecmaVersion: 2019,
-        project: join(__dirname, './tsconfig.json'),
+        project: './tsconfig.json',
         sourceType: 'module',
     },
     plugins: ['import', 'fp-ts'],


### PR DESCRIPTION
Use relative path for tsconfig `project` value to allow extending this configuration in monorepos.