### PR TITLE
Removed parser project config

### DIFF
--- a/index.mts
+++ b/index.mts
@@ -43,7 +43,6 @@ export const facileBase = tseslint.config(
             sourceType: 'module',
             parserOptions: {
                 projectService: true,
-                project: './tsconfig.json',
                 ecmaVersion: 2022,
             },
         },


### PR DESCRIPTION
The last version of typescript-eslint added this check
https://github.com/typescript-eslint/typescript-eslint/pull/11333

Removed project config in order to use projectService by default